### PR TITLE
Added logic for Custom Issue title and Breadcrumbs to be sent to Sentry

### DIFF
--- a/force-app/main/default/classes/SYS_CustomException.cls
+++ b/force-app/main/default/classes/SYS_CustomException.cls
@@ -1,0 +1,11 @@
+/**
+ * @description       : 
+ * @author            : Jheel
+ * @group             : 
+ * @last modified on  : 04-28-2021
+ * @last modified by  : Jheel
+ * Modifications Log 
+ * Ver   Date         Author   Modification
+ * 1.0   04-28-2021   Jheel   Initial Version
+**/
+public class SYS_CustomException extends Exception {}

--- a/force-app/main/default/classes/SYS_CustomException.cls
+++ b/force-app/main/default/classes/SYS_CustomException.cls
@@ -8,4 +8,4 @@
  * Ver   Date         Author   Modification
  * 1.0   04-28-2021   Jheel   Initial Version
 **/
-public class SYS_CustomException extends Exception {}
+global class SYS_CustomException extends Exception {}

--- a/force-app/main/default/classes/SYS_CustomException.cls-meta.xml
+++ b/force-app/main/default/classes/SYS_CustomException.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>45.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/Sentry.cls
+++ b/force-app/main/default/classes/Sentry.cls
@@ -1,16 +1,33 @@
 /**
- * Created by Jacob Mather <jmather@jmather.com> on 2019-06-25.
- */
-
+ * @description       : 
+ * @author            : jmather
+ * @group             : 
+ * @last modified on  : 04-28-2021
+ * @last modified by  : Jheel
+ * Modifications Log 
+ * Ver   Date         Author    Modification
+ * 1.0   08-10-2019   jmather   Initial Version
+ * 1.1   04-28-2021   Jheel     Added a method to send custom title and breadcrumbs to Sentry
+**/
 public without sharing class Sentry {
     public static void record(Exception e) {
         Sentry_Event err = convertExceptionToError(e);
+        sendEvent(err);
+    }
 
+    public static void record(String issueTitle, Exception e, List<Sentry_LogMessage> lExtraMessages) 
+    {
+        Sentry_Event err = convertExceptionToError(issueTitle, e, lExtraMessages);
         sendEvent(err);
     }
 
     private static Sentry_Event convertExceptionToError(Exception e) {
         return new Sentry_Event(e);
+    }
+
+    private static Sentry_Event convertExceptionToError(String issueTitle, Exception e, List<Sentry_LogMessage> lExtraMessages) 
+    {
+        return new Sentry_Event(issueTitle, e, lExtraMessages);
     }
 
     private static void sendEvent(Sentry_Event err) {

--- a/force-app/main/default/classes/SentryTest.cls
+++ b/force-app/main/default/classes/SentryTest.cls
@@ -1,7 +1,14 @@
 /**
- * Created by jmather on 2019-08-10.
- */
-
+ * @description       : 
+ * @author            : jmather
+ * @group             : 
+ * @last modified on  : 04-28-2021
+ * @last modified by  : Jheel
+ * Modifications Log 
+ * Ver   Date         Author    Modification
+ * 1.0   08-10-2019   jmather   Initial Version
+ * 1.1   04-28-2021   Jheel     Added new methods RecordwithCustomException() and RecordCustomExceptionWithoutSendingToSentry() for test class coverge
+**/
 @IsTest
 public with sharing class SentryTest {
     @IsTest
@@ -30,5 +37,51 @@ public with sharing class SentryTest {
         Test.stopTest();
 
         System.assertNotEquals(null, ex);
+    }
+    
+    @IsTest
+    static void RecordwithCustomException() 
+    {
+        Exception ex;
+
+        Test.setMock(HttpCalloutMock.class, new Sentry_ApiMock());
+
+        Sentry_TestingController controller = new Sentry_TestingController();
+
+        Sentry_Active_Config__c config = Sentry_Active_Config__c.getOrgDefaults();
+        config.IsIssueCreationDisabled__c = false;
+        config.IsDebug__c = true;
+        config.Sentry_Config__c = 'Test';
+        config.Environment_Name__c = 'Test';
+        insert config;
+
+        Test.startTest();
+        controller.triggerCustomException();
+        Test.stopTest();
+
+        System.assertEquals(null, ex);
+    }
+    
+    @IsTest
+    static void RecordCustomExceptionWithoutSendingToSentry() 
+    {
+        Exception ex;
+
+        Test.setMock(HttpCalloutMock.class, new Sentry_ApiMock());
+
+        Sentry_TestingController controller = new Sentry_TestingController();
+
+        Sentry_Active_Config__c config = Sentry_Active_Config__c.getOrgDefaults();
+        config.IsIssueCreationDisabled__c = true;
+        config.IsDebug__c = true;
+        config.Sentry_Config__c = 'Test';
+        config.Environment_Name__c = 'Test';
+        insert config;
+
+        Test.startTest();
+        controller.triggerCustomException();
+        Test.stopTest();
+
+        System.assertEquals(null, ex);
     }
 }

--- a/force-app/main/default/classes/Sentry_Event.cls
+++ b/force-app/main/default/classes/Sentry_Event.cls
@@ -1,7 +1,14 @@
 /**
- * Created by Jacob Mather <jmather@jmather.com> on 2019-03-25.
- */
-
+ * @description       : 
+ * @author            : jmather
+ * @group             : 
+ * @last modified on  : 04-28-2021
+ * @last modified by  : Jheel
+ * Modifications Log 
+ * Ver   Date         Author    Modification
+ * 1.0   08-10-2019   jmather   Initial Version
+ * 1.1   04-28-2021   Jheel     Added logic to send proper detailed data to Sentry with Breadcrumbs as well
+**/
 public without sharing class Sentry_Event {
     // uuid
     public String event_id;
@@ -42,6 +49,8 @@ public without sharing class Sentry_Event {
 
     public Map<String, Object> exceptionValues = new Map<String, Object> { 'values' => new List<Map<String, Object>>() };
 
+    public Map<String, Object> breadcrumbsValues = new Map<String, Object> { 'values' => new List<Map<String, Object>>() };
+
     public String messageFormatted;
 
     public String[] messageParams;
@@ -58,16 +67,31 @@ public without sharing class Sentry_Event {
     }
 
     public Sentry_Event(Exception ex) {
+        this(null, ex, null);
+    }
+
+    // Custom Method with custom issueTitle and extra messages
+    public Sentry_Event(String issueTitle, Exception ex, List<Sentry_LogMessage> lExtraMessages) {
         initialize();
 
         Sentry_Log.logSentry('Got exception: ' + ex);
         Sentry_Log.logSentry('Got stack: ' + ex.getStackTraceString());
 
-        Map<String, Object> exData = Sentry_Context.create();
-        Map<String, Object> exDataStack = Sentry_Context.create();
+        Map<String, Object> exceptionData = Sentry_Context.create();
+        Map<String, Object> exceptionDataStack = Sentry_Context.create();
 
-        exData.put('type', ex.getTypeName());
-        exData.put('message', JSON.serialize(ex.getMessage()));
+        // For setting custom title for the issue which will be created
+        if(String.isNotBlank(issueTitle))
+        {
+            exceptionData.put('type', issueTitle);
+        }
+        // Default title will be the type of exception occured.
+        else
+        {
+            exceptionData.put('type', ex.getTypeName());
+        }
+        
+        exceptionData.put('message', JSON.serialize(ex.getMessage()));
 
         List<Map<String, Object>> frames = new List<Map<String, Object>>();
 
@@ -80,29 +104,85 @@ public without sharing class Sentry_Event {
             String line = lines[i];
             Pattern p = Pattern.compile('Class\\.([^\\.]+)\\.([^:]+): line ([0-9]+), column ([0-9]+)');
             Matcher m = p.matcher(line);
-            if (m.find()) {
+            // Sample: Class.SampleClass.execute: line 36, column 1
+            if (m.find()) 
+            {
+                System.debug('@@m:--'+m);
                 frames.add(new Map<String, Object> {
                         'class' => m.group(1),
-                        'file' => m.group(1) + '.cls',
+                        'filename' => m.group(1) + '.cls',
                         'function' => m.group(1) + '.' + m.group(2) + ', line ' + m.group(3),
-                        'line' => m.group(3),
-                        'column' => m.group(4)
+                        'lineno' => Integer.valueOf(m.group(3)),
+                        'column' => Integer.valueOf(m.group(4)),
+                        'in_app'=> true,
+                        'vars' => new Map<String, Object> {
+                            'column' => m.group(4),
+                            'line' => Integer.valueOf(m.group(3)),
+                            'class'=> m.group(1),
+                            'function' => m.group(2)
+                        }
                 });
+            }
+            else
+            {
+                p = Pattern.compile('Class\\.([^\\.]+): line ([0-9]+), column ([0-9]+)');
+                m = p.matcher(line);
+                // Sample: Class.SampleClass1: line 595, column 1
+                if (m.find()) 
+                {
+                    System.debug('@@m:--'+m);
+                    frames.add(new Map<String, Object> {
+                            'class' => m.group(1),
+                            'filename' => m.group(1) + '.cls',
+                            'function' => m.group(1) /*+ '.' + m.group(2) */+ ', line ' + m.group(2),
+                            'lineno' => Integer.valueOf(m.group(2)),
+                            'column' => Integer.valueOf(m.group(3)),
+                            'in_app'=> true,
+                            'vars' => new Map<String, Object> {
+                                'column' => m.group(3),
+                                'line' => Integer.valueOf(m.group(2)),
+                                'class'=> m.group(1)
+                            }
+                    });
+                }
             }
         }
 
-        exDataStack.put('frames', frames);
-        exData.put('stacktrace', exDataStack);
+        exceptionDataStack.put('frames', frames);
+        exceptionData.put('stacktrace', exceptionDataStack);
 
-        extra.put('cause', ex.getCause());
-        extra.put('line_number', ex.getLineNumber());
+        // add "value" in exceptionData
+        exceptionData.put('value', ex.getTypeName()+' '+ex.getMessage());
+        exceptionData.put('cause', ex.getCause());
+        exceptionData.put('line_number', ex.getLineNumber());
 
-        addException(exData);
+        addException(exceptionData);
         message = ex.getMessage();
+
+        // For loop for adding extra messages in the issue
+        if(lExtraMessages != null && !lExtraMessages.isEmpty())
+        {
+            for(Sentry_LogMessage objSLogMessage: lExtraMessages)
+            {
+                Map<String, Object> extraData = Sentry_Context.create();
+                extraData.put('type', objSLogMessage.type);  
+                extraData.put('category', objSLogMessage.category);  
+                extraData.put('level', objSLogMessage.level);  
+                extraData.put('timestamp', objSLogMessage.ts.formatGmt('yyyy-MM-dd') + 'T' + objSLogMessage.ts.formatGmt('HH:mm:ss') + 'Z');  
+                extraData.put('message', objSLogMessage.message);
+                
+                // Adding extra messages
+                addbreadcrumbs(extraData);
+            }
+        }
     }
 
     private void addException(Map<String, Object> exData) {
         ((List<Map<String, Object>>)exceptionValues.get('values')).add(exData);
+    }
+
+     private void addbreadcrumbs(Map<String, Object> exData) {
+        ((List<Map<String, Object>>)breadcrumbsValues.get('values')).add(exData);
     }
 
     private void initialize() {
@@ -112,7 +192,7 @@ public without sharing class Sentry_Event {
 
         timestamp = Datetime.now().formatGmt('yyyy-MM-dd') + 'T' + Datetime.now().formatGmt('HH:mm:ss') + 'Z';
 
-        level = 'error';
+        level = Sentry_LogMessage.LEVEL_ERROR;
 
         environment = Sentry_Config.getEnvironmentName();
     }
@@ -127,6 +207,7 @@ public without sharing class Sentry_Event {
         msg.put('platform', platform);
         msg.put('level', level);
         msg.put('exception', exceptionValues);
+        msg.put('breadcrumbs', breadcrumbsValues);
         return msg;
     }
 }

--- a/force-app/main/default/classes/Sentry_LogMessage.cls
+++ b/force-app/main/default/classes/Sentry_LogMessage.cls
@@ -1,7 +1,14 @@
 /**
- * Created by jmather on 2019-08-08.
- */
-
+ * @description       : 
+ * @author            : jmather
+ * @group             : 
+ * @last modified on  : 04-28-2021
+ * @last modified by  : Jheel
+ * Modifications Log 
+ * Ver   Date         Author    Modification
+ * 1.0   08-10-2019   jmather   Initial Version
+ * 1.1   04-28-2021   Jheel     Added few more variables to store other data as well
+**/
 global with sharing class Sentry_LogMessage {
     global static final String LEVEL_ERROR = 'error';
     global static final String LEVEL_WARN = 'warn';
@@ -11,6 +18,8 @@ global with sharing class Sentry_LogMessage {
     public static final String LEVEL_SENTRY_DEBUG = 'sys-debug';
 
     global String level { get; set; } { level = LEVEL_INFO; }
+    global String type { get; set; } { type = LEVEL_DEBUG; }
+    global String category { get; set; } { category = LEVEL_DEBUG; }
     global String message { get; set; }
     global Datetime ts { get; private set; } { ts = Datetime.now(); }
     global Map<String, String> data { get; set; } { data = new Map<String, String>(); }
@@ -20,9 +29,22 @@ global with sharing class Sentry_LogMessage {
         this.message = message;
     }
 
+    global Sentry_LogMessage(String level, String type, String category, String message) 
+    {
+        this.level = (level == LEVEL_ERROR) ? LEVEL_ERROR : LEVEL_INFO;
+        this.type = type;
+        this.category = category;
+        this.message = message;
+    }
+
     global Sentry_LogMessage(String level, String message, Map<String, String> logData) {
         this(level, message);
+        this.data = logData;
+    }
 
+    global Sentry_LogMessage(String level, String type, String category, String message, Map<String, String> logData) 
+    {
+        this(level, type, category, message);
         this.data = logData;
     }
 }

--- a/force-app/main/default/classes/Sentry_TestingController.cls
+++ b/force-app/main/default/classes/Sentry_TestingController.cls
@@ -1,7 +1,14 @@
 /**
- * Created by jmather on 2019-08-08.
- */
-
+ * @description       : 
+ * @author            : jmather
+ * @group             : 
+ * @last modified on  : 04-28-2021
+ * @last modified by  : Jheel
+ * Modifications Log 
+ * Ver   Date         Author    Modification
+ * 1.0   08-10-2019   jmather   Initial Version
+ * 1.1   04-28-2021   Jheel     Added logic to trigger Custom Exception
+**/
 public with sharing class Sentry_TestingController {
     public PageReference triggerCapturedException() {
         try {
@@ -11,6 +18,14 @@ public with sharing class Sentry_TestingController {
             throw e;
         }
 
+        return null;
+    }
+    
+    public PageReference triggerCustomException() 
+    {
+        List<Sentry_LogMessage> lExtraMessages = new List<Sentry_LogMessage>();
+     	lExtraMessages.add(new Sentry_LogMessage(Sentry_LogMessage.LEVEL_INFO, Sentry_LogMessage.LEVEL_DEBUG, Sentry_LogMessage.LEVEL_DEBUG,'Testing debug 1', new Map<String, String>()));   
+        Sentry.record('Custom Issue Title',new SYS_CustomException('Custom Exception'), lExtraMessages);
         return null;
     }
 }


### PR DESCRIPTION
I have made enhancements in the existing code to send proper values to Sentry and also added logic with which if we want to send our custom title for any issue we can send that as well. Also, I have added logic to send breadcrumbs as well which helps in getting some proper debugs with which we can get to know the details of the exception.